### PR TITLE
Fixing async syntax for python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.7"
 # command to install dependencies
 install:
   - pip install .

--- a/src/pytractor/mixins.py
+++ b/src/pytractor/mixins.py
@@ -75,14 +75,14 @@ class WebDriverMixin(object):
         self.set_script_timeout(script_timeout)
 
     def _execute_client_script(self, script_name, *args, **kwargs):
-        async = kwargs.pop('async', True)
+        is_async = kwargs.pop('is_async', True)
         file_name = '{}.js'.format(script_name)
         js_script = resource_string(__name__,
                                     '{}/{}'.format(CLIENT_SCRIPTS_DIR,
                                                    file_name))
         if js_script:
             js_script = js_script.decode('UTF-8')
-        if async:
+        if is_async:
             result = self.execute_async_script(js_script, *args)
         else:
             result = self.execute_script(js_script, *args)
@@ -94,7 +94,7 @@ class WebDriverMixin(object):
         else:
             return self._execute_client_script('waitForAngular',
                                                self._root_element,
-                                               async=True)
+                                               is_async=True)
 
     def execute(self, driver_command, params=None):
         # We also get called from WebElement methods/properties.
@@ -131,13 +131,13 @@ class WebDriverMixin(object):
     @angular_wait_required
     def location_abs_url(self):
         return self._execute_client_script('getLocationAbsUrl',
-                                           self._root_element, async=False)
+                                           self._root_element, is_async=False)
 
     @angular_wait_required
     def find_elements_by_repeater(self, descriptor, using=None):
         return self._execute_client_script('findAllRepeaterRows',
                                            descriptor, False, using,
-                                           async=False)
+                                           is_async=False)
 
     @angular_wait_required
     def find_element(self, *args, **kwargs):
@@ -150,7 +150,7 @@ class WebDriverMixin(object):
     @angular_wait_required
     def find_elements_by_binding(self, descriptor, using=None):
         elements = self._execute_client_script('findBindings', descriptor,
-                                               False, using, async=False)
+                                               False, using, is_async=False)
         return elements
 
     def find_element_by_binding(self, descriptor, using=None):
@@ -176,7 +176,7 @@ class WebDriverMixin(object):
     @angular_wait_required
     def find_elements_by_exact_binding(self, descriptor, using=None):
         elements = self._execute_client_script('findBindings', descriptor,
-                                               True, using, async=False)
+                                               True, using, is_async=False)
         return elements
 
     def find_element_by_model(self, descriptor, using=None):
@@ -192,7 +192,7 @@ class WebDriverMixin(object):
     @angular_wait_required
     def find_elements_by_model(self, descriptor, using=None):
         elements = self._execute_client_script('findByModel', descriptor,
-                                               using, async=False)
+                                               using, is_async=False)
         # Workaround for issue #10: findByModel.js returns None instead of empty
         # list if no element has been found.
         if elements is None:
@@ -233,5 +233,5 @@ class WebDriverMixin(object):
     @angular_wait_required
     def set_location(self, url):
         result = self._execute_client_script('setLocation', self._root_element,
-                                             url, async=False)
+                                             url, is_async=False)
         return result

--- a/src/pytractor/tests/unit/test_mixins.py
+++ b/src/pytractor/tests/unit/test_mixins.py
@@ -108,7 +108,7 @@ class WebDriverMixinTest(unittest.TestCase):
                                        self.mock_root_element)
 
     @patch('pytractor.mixins.resource_string')
-    def verify__execute_client_script_call(self, async, mock_resource_string):
+    def verify__execute_client_script_call(self, is_async, mock_resource_string):
         with patch.multiple(
             self.instance,
             execute_async_script=DEFAULT, execute_script=DEFAULT,
@@ -121,7 +121,7 @@ class WebDriverMixinTest(unittest.TestCase):
                                             'execute_async_script')]
             mock_arg = MagicMock()
             result = self.instance._execute_client_script('SCRIPT', mock_arg,
-                                                          async=async)
+                                                          is_async=is_async)
         # the script was read correctly with resource_string()
         mock_resource_string.assert_called_once_with(
             'pytractor.mixins',
@@ -129,7 +129,7 @@ class WebDriverMixinTest(unittest.TestCase):
         )
         # execute_async_script or execute_script were called (but not both)
         script_content = mock_resource_string.return_value.decode()
-        if async:
+        if is_async:
             mock_execute_async_script.assert_called_once_with(script_content,
                                                               mock_arg)
             self.assertEqual(len(mock_execute_script.mock_calls), 0)
@@ -164,7 +164,7 @@ class WebDriverMixinTest(unittest.TestCase):
     def test_wait_for_angular(self):
         self.verify_function_executes_script_with(
             self.instance.wait_for_angular,
-            'waitForAngular', self.mock_root_element, async=True
+            'waitForAngular', self.mock_root_element, is_async=True
         )
 
     def test_wait_for_angular_does_not_call_script_if_ignore_synchronization(
@@ -274,7 +274,7 @@ class WebDriverMixinTest(unittest.TestCase):
                                                             mock_using)
         mock_methods['wait_for_angular'].assert_called_once_with()
         mock_methods['_execute_client_script'].assert_called_once_with(
-            'findBindings', mock_descriptor, False, mock_using, async=False
+            'findBindings', mock_descriptor, False, mock_using, is_async=False
         )
         self.assertIs(result,
                       mock_methods['_execute_client_script'].return_value)
@@ -439,7 +439,7 @@ class WebDriverMixinTest(unittest.TestCase):
 
         mock_methods['wait_for_angular'].assert_called_once_with()
         mock_methods['_execute_client_script'].assert_called_once_with(
-            'findBindings', mock_descriptor, True, mock_using, async=False
+            'findBindings', mock_descriptor, True, mock_using, is_async=False
         )
         self.assertIs(result,
                       mock_methods['_execute_client_script'].return_value)
@@ -486,7 +486,7 @@ class WebDriverMixinTest(unittest.TestCase):
 
         mock_methods['wait_for_angular'].assert_called_once_with()
         mock_methods['_execute_client_script'].assert_called_once_with(
-            'findByModel', mock_descriptor, mock_using, async=False
+            'findByModel', mock_descriptor, mock_using, is_async=False
         )
         self.assertIs(result,
                       mock_methods['_execute_client_script'].return_value)
@@ -514,7 +514,7 @@ class WebDriverMixinTest(unittest.TestCase):
 
         mock_methods['wait_for_angular'].assert_called_once_with()
         mock_methods['_execute_client_script'].assert_called_once_with(
-            'getLocationAbsUrl', self.instance._root_element, async=False
+            'getLocationAbsUrl', self.instance._root_element, is_async=False
         )
         self.assertIs(result,
                       mock_methods['_execute_client_script'].return_value)
@@ -529,7 +529,7 @@ class WebDriverMixinTest(unittest.TestCase):
 
         mock_methods['wait_for_angular'].assert_called_once_with()
         mock_methods['_execute_client_script'].assert_called_once_with(
-            'setLocation', self.instance._root_element, url, async=False
+            'setLocation', self.instance._root_element, url, is_async=False
         )
         self.assertIs(result,
                       mock_methods['_execute_client_script'].return_value)


### PR DESCRIPTION
'async' become reserved keyword in Python 3.7 so variable should be renamed to avoid SyntaxError:
```
  File "/home/radler/PycharmProjects/ui_testing/env/lib/python3.7/site-packages/pytractor/webdriver.py", line 22, in <module>
    from .mixins import WebDriverMixin
  File "/home/radler/PycharmProjects/ui_testing/env/lib/python3.7/site-packages/pytractor/mixins.py", line 78
    async = kwargs.pop('async', True)
          ^
SyntaxError: invalid syntax
```